### PR TITLE
Version 2.26.9.3

### DIFF
--- a/LenovoLegionToolkit.WPF/App.xaml.cs
+++ b/LenovoLegionToolkit.WPF/App.xaml.cs
@@ -15,6 +15,7 @@ using LenovoLegionToolkit.Lib.Features.WhiteKeyboardBacklight;
 using LenovoLegionToolkit.Lib.Integrations;
 using LenovoLegionToolkit.Lib.Listeners;
 using LenovoLegionToolkit.Lib.Macro;
+using LenovoLegionToolkit.Lib.Services;
 using LenovoLegionToolkit.Lib.Settings;
 using LenovoLegionToolkit.Lib.SoftwareDisabler;
 using LenovoLegionToolkit.Lib.System;


### PR DESCRIPTION
* Resolved an issue where caused after upgraded LLT or reinstalled LLT, The sensor dashboard shows CPU only.
* Resolved an issue where caused if using --disable-update-checker argument, the Update Method lable still visible.
* Rebase from newest upstream. Thank you for all your works.